### PR TITLE
update location of additional license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,4 +15,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-This license file does not apply to the content of /stories. A separate license file is included in that directory.
+This license file does not apply to the content of /static/stories. A separate license file is included in that directory.


### PR DESCRIPTION
This PR updates the location of the additional license (namely: CC-BY for the stories), as the `/stories` folder is not inside root, but inside `/static`.